### PR TITLE
Made it possible to pass location of HeliosDB.js as an option

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -2,7 +2,8 @@ var Helios;
 (function (Helios) {
     var GraphDatabase = (function () {
         function GraphDatabase(options) {
-            this.worker = new Worker('./helios/lib/heliosDB.js');
+	    var heliosDBPath = ('heliosDBPath' in options) ? options['heliosDBPath'] : './helios/lib/heliosDB.js';
+            this.worker = new Worker(heliosDBPath);
             this.db = Q_COMM.Connection(this.worker, null, {
                 max: 1024
             });


### PR DESCRIPTION
Currently location of HeliosDB.js is hardcoded and in some cases it can cause problems (e.g. when user want's different directory structure). What do you think about making it possible to set path to HeliosDB.js using parameters?
